### PR TITLE
Add HTTP integration test

### DIFF
--- a/crates/tenx-mcp/tests/http_integration.rs
+++ b/crates/tenx-mcp/tests/http_integration.rs
@@ -1,0 +1,98 @@
+use async_trait::async_trait;
+use serde_json::json;
+use std::collections::HashMap;
+use tenx_mcp::{
+    schema::{self, *},
+    Client, Result, Server, ServerConn, ServerCtx, ServerHandle, ServerAPI,
+};
+
+#[derive(Default)]
+struct EchoConnection;
+
+#[async_trait]
+impl ServerConn for EchoConnection {
+    async fn initialize(
+        &self,
+        _context: &ServerCtx,
+        _protocol_version: String,
+        _capabilities: ClientCapabilities,
+        _client_info: Implementation,
+    ) -> Result<InitializeResult> {
+        Ok(InitializeResult::new("http-echo-server", "0.1.0").with_capabilities(
+            ServerCapabilities::default().with_tools(None),
+        ))
+    }
+
+    async fn list_tools(
+        &self,
+        _context: &ServerCtx,
+        _cursor: Option<Cursor>,
+    ) -> Result<ListToolsResult> {
+        let schema = ToolInputSchema {
+            schema_type: "object".to_string(),
+            properties: Some({
+                let mut props = HashMap::new();
+                props.insert("message".to_string(), json!({"type": "string"}));
+                props
+            }),
+            required: Some(vec!["message".to_string()]),
+        };
+        Ok(ListToolsResult::default().with_tool(
+            Tool::new("echo", schema).with_description("Echo message"),
+        ))
+    }
+
+    async fn call_tool(
+        &self,
+        _context: &ServerCtx,
+        name: String,
+        arguments: Option<HashMap<String, serde_json::Value>>,
+    ) -> Result<CallToolResult> {
+        use tenx_mcp::Error;
+        if name != "echo" {
+            return Err(Error::ToolNotFound(name));
+        }
+        let args = arguments.ok_or_else(|| Error::InvalidParams("Missing args".into()))?;
+        let message = args
+            .get("message")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::InvalidParams("Missing message".into()))?;
+        Ok(CallToolResult::new().with_text_content(message.to_string()).is_error(false))
+    }
+}
+
+#[tokio::test]
+async fn test_http_echo_tool_integration() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // Bind to an available port first to avoid conflicts
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let addr_str = format!("{}:{}", addr.ip(), addr.port());
+    let server = Server::default().with_connection(EchoConnection::default);
+    let server_handle = server.serve_http(&addr_str).await.unwrap();
+
+    // Connect HTTP client
+    let mut client = Client::new("http-test-client", "0.1.0");
+    let init = client
+        .connect_http(&format!("http://{}", addr_str))
+        .await
+        .unwrap();
+    assert_eq!(init.server_info.name, "http-echo-server");
+
+    // Call echo tool
+    let mut args = HashMap::new();
+    args.insert("message".to_string(), json!("hello"));
+    let result = client.call_tool("echo", args).await.unwrap();
+    if let Some(schema::Content::Text(text)) = result.content.first() {
+        assert_eq!(text.text, "hello");
+    } else {
+        panic!("expected text response");
+    }
+
+    drop(client);
+    // Drop server handle to stop background task
+    drop(server_handle);
+}


### PR DESCRIPTION
## Summary
- add integration test covering HTTP server/client interaction

## Testing
- `cargo test --workspace --tests --quiet`
- `cargo test --test http_integration -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6857d2cae854833384e4d45800b87483