### PR TITLE
Simplify tests via improved utilities

### DIFF
--- a/crates/tenx-mcp/src/testutils.rs
+++ b/crates/tenx-mcp/src/testutils.rs
@@ -16,6 +16,7 @@
 
 use tokio::io::{self, AsyncRead, AsyncWrite};
 use tokio::sync::broadcast;
+use tracing_subscriber as _; // bring dependency for init_tracing helper
 
 use crate::{
     error::Result,
@@ -211,4 +212,22 @@ impl Default for TestClientContext {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Create a standalone [`ServerCtx`] with its own broadcast channel.
+pub fn new_server_ctx() -> ServerCtx {
+    let (tx, _) = broadcast::channel(100);
+    test_server_ctx(tx)
+}
+
+/// Create a standalone [`ClientCtx`] with its own broadcast channel.
+pub fn new_client_ctx() -> ClientCtx {
+    let (tx, _) = broadcast::channel(100);
+    test_client_ctx(tx)
+}
+
+/// Initialize a tracing subscriber for tests.
+/// It is safe to call this multiple times.
+pub fn init_tracing() {
+    let _ = tracing_subscriber::fmt::try_init();
 }

--- a/crates/tenx-mcp/tests/bidi.rs
+++ b/crates/tenx-mcp/tests/bidi.rs
@@ -8,7 +8,10 @@ use async_trait::async_trait;
 use std::sync::{Arc, Mutex};
 use tenx_mcp::{
     schema::*,
-    testutils::{connected_client_and_server_with_conn, shutdown_client_and_server},
+    testutils::{
+        connected_client_and_server_with_conn, shutdown_client_and_server,
+        init_tracing,
+    },
     ClientAPI, ClientConn, ClientCtx, Result, ServerAPI, ServerConn, ServerCtx,
 };
 
@@ -203,7 +206,7 @@ impl ServerConn for TestServer {
 
 #[tokio::test]
 async fn test_server_calls_client_during_request() {
-    let _ = tracing_subscriber::fmt::try_init();
+    init_tracing();
 
     // Create test client and server with call tracking
     let (test_client, client_calls) = TestClient::new();
@@ -293,7 +296,7 @@ async fn test_server_calls_client_during_request() {
 
 #[tokio::test]
 async fn test_client_server_ping_pong() {
-    let _ = tracing_subscriber::fmt::try_init();
+    init_tracing();
 
     let (test_client, client_calls) = TestClient::new();
     let (test_server, server_calls) = TestServer::new();

--- a/crates/tenx-mcp/tests/error_handling_test.rs
+++ b/crates/tenx-mcp/tests/error_handling_test.rs
@@ -7,12 +7,12 @@ use std::collections::HashMap;
 use tenx_mcp::{schema, testutils, Error, Result, ServerConn, ServerCtx};
 
 fn create_test_context() -> ServerCtx {
-    let (notification_tx, _) = tokio::sync::broadcast::channel(100);
-    testutils::test_server_ctx(notification_tx)
+    testutils::new_server_ctx()
 }
 
 #[tokio::test]
 async fn test_method_not_found() {
+    testutils::init_tracing();
     // Test that the default tools_call implementation returns ToolNotFound
     #[derive(Default)]
     struct MinimalConnection;
@@ -60,6 +60,7 @@ async fn test_method_not_found() {
 
 #[tokio::test]
 async fn test_invalid_params() {
+    testutils::init_tracing();
     // Test parameter validation in tools_call
     #[derive(Default)]
     struct ConnectionWithValidation;
@@ -172,6 +173,7 @@ async fn test_invalid_params() {
 
 #[tokio::test]
 async fn test_successful_response() {
+    testutils::init_tracing();
     // Test successful tool listing and other operations
     #[derive(Default)]
     struct ConnectionWithTools;
@@ -275,6 +277,7 @@ async fn test_successful_response() {
 
 #[tokio::test]
 async fn test_error_propagation() {
+    testutils::init_tracing();
     // Test that errors are properly propagated through the Connection trait
     #[derive(Default)]
     struct FaultyConnection;

--- a/crates/tenx-mcp/tests/http_integration.rs
+++ b/crates/tenx-mcp/tests/http_integration.rs
@@ -3,6 +3,7 @@ use serde_json::json;
 use std::collections::HashMap;
 use tenx_mcp::{
     schema::{self, *},
+    testutils::{init_tracing, shutdown_client_and_server},
     Client, Result, Server, ServerConn, ServerCtx, ServerHandle, ServerAPI,
 };
 
@@ -63,7 +64,7 @@ impl ServerConn for EchoConnection {
 
 #[tokio::test]
 async fn test_http_echo_tool_integration() {
-    let _ = tracing_subscriber::fmt::try_init();
+    init_tracing();
 
     // Bind to an available port first to avoid conflicts
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -92,7 +93,5 @@ async fn test_http_echo_tool_integration() {
         panic!("expected text response");
     }
 
-    drop(client);
-    // Drop server handle to stop background task
-    drop(server_handle);
+    shutdown_client_and_server(client, server_handle).await;
 }

--- a/crates/tenx-mcp/tests/notifications.rs
+++ b/crates/tenx-mcp/tests/notifications.rs
@@ -1,9 +1,11 @@
 use async_trait::async_trait;
-use tenx_mcp::{schema, ClientConn, ClientCtx, Result, ServerConn, ServerCtx};
+use tenx_mcp::{
+    schema, ClientConn, ClientCtx, Result, ServerConn, ServerCtx, testutils::init_tracing,
+};
 
 #[tokio::test]
 async fn test_server_to_client_notifications() {
-    let _ = tracing_subscriber::fmt::try_init();
+    init_tracing();
 
     use tenx_mcp::testutils::connected_client_and_server_with_conn;
     use tokio::sync::oneshot;

--- a/crates/tenx-mcp/tests/protocol_compliance.rs
+++ b/crates/tenx-mcp/tests/protocol_compliance.rs
@@ -162,15 +162,13 @@ impl ServerConn for TestConnection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::sync::broadcast;
-
     fn create_test_context() -> ServerCtx {
-        let (notification_tx, _) = broadcast::channel(100);
-        testutils::test_server_ctx(notification_tx)
+        testutils::new_server_ctx()
     }
 
     #[tokio::test]
     async fn test_echo_tool() {
+        testutils::init_tracing();
         let conn = TestConnection::new();
 
         // Test tools list
@@ -226,6 +224,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_tool() {
+        testutils::init_tracing();
         let conn = TestConnection::new();
 
         // Test tools list contains add tool
@@ -320,6 +319,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_protocol_compliance() {
+        testutils::init_tracing();
         // Test that our tools follow the MCP protocol specification
         let conn = TestConnection::new();
         let context = create_test_context();

--- a/crates/tenx-mcp/tests/rmcp_integration.rs
+++ b/crates/tenx-mcp/tests/rmcp_integration.rs
@@ -90,7 +90,7 @@ async fn test_tenx_server_with_rmcp_client() {
     // Initialize a tracing subscriber so that we get helpful debug output if
     // this test fails or hangs. We deliberately call `try_init` so that it's
     // no-op when a subscriber has already been installed by another test.
-    let _ = tracing_subscriber::fmt::try_init();
+    tenx_mcp::testutils::init_tracing();
     // Create bidirectional streams for communication using the shared test
     // utility.
     let (server_reader, server_writer, client_reader, client_writer) = make_duplex_pair();
@@ -169,6 +169,7 @@ async fn test_tenx_server_with_rmcp_client() {
 
 #[tokio::test]
 async fn test_rmcp_server_with_tenx_client() {
+    tenx_mcp::testutils::init_tracing();
     use rmcp::{
         handler::server::ServerHandler,
         service::{RequestContext, RoleServer},


### PR DESCRIPTION
## Summary
- extend `testutils` with helpers for new contexts and tracing
- update integration tests to use new helpers
- clean up various test setups for readability

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6857eb8d7d388333ad05fa8747f6c280