### PR TITLE
Fix immediate server shutdown

### DIFF
--- a/crates/tenx-mcp/src/server.rs
+++ b/crates/tenx-mcp/src/server.rs
@@ -77,7 +77,10 @@ where
     /// This is a convenience method that starts the server and waits for completion
     pub(crate) async fn serve(self, transport: Box<dyn Transport>) -> Result<()> {
         let handle = ServerHandle::new(self, transport).await?;
-        handle.stop().await
+        handle
+            .handle
+            .await
+            .map_err(|e| Error::InternalError(format!("Server task failed: {e}")))
     }
 
     /// Serve connections from stdin/stdout


### PR DESCRIPTION
## Summary
- fix bug in server::serve so the server waits for completion instead of immediately cancelling itself

## Testing
- `cargo run --example basic_client_stdio`
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_685a178d95fc833397d1843add15402a