### PR TITLE
Store CSRF state token in OAuth client

### DIFF
--- a/crates/tenx-mcp/examples/dynamic_registration.rs
+++ b/crates/tenx-mcp/examples/dynamic_registration.rs
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting OAuth authorization flow...");
 
     // Get authorization URL
-    let (auth_url, csrf_token) = oauth_client.get_authorization_url();
+    let (auth_url, _csrf_token) = oauth_client.get_authorization_url();
 
     info!("Opening browser for authorization...");
     info!("If the browser doesn't open, visit: {}", auth_url);
@@ -185,11 +185,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Waiting for OAuth callback on port {}...", args.port);
 
     let (code, state) = callback_server.wait_for_callback().await?;
-
-    // Verify CSRF token
-    if state != *csrf_token.secret() {
-        return Err("CSRF token mismatch".into());
-    }
 
     info!("Received authorization code, exchanging for token...");
 

--- a/crates/tenx-mcp/examples/ghusers.rs
+++ b/crates/tenx-mcp/examples/ghusers.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut oauth_client = OAuth2Client::new(config)?;
 
         // Get authorization URL
-        let (auth_url, csrf_token) = oauth_client.get_authorization_url();
+        let (auth_url, _csrf_token) = oauth_client.get_authorization_url();
 
         println!("Opening browser for GitHub authorization...");
         println!("If the browser doesn't open, visit: {auth_url}");
@@ -145,11 +145,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         debug!("Waiting for OAuth callback on port {}...", args.port);
 
         let (code, state) = callback_server.wait_for_callback().await?;
-
-        // Verify CSRF token
-        if state != *csrf_token.secret() {
-            return Err("CSRF token mismatch".into());
-        }
 
         debug!("Received authorization code, exchanging for token...");
 

--- a/crates/tenx-mcp/examples/oauth_client.rs
+++ b/crates/tenx-mcp/examples/oauth_client.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut oauth_client = OAuth2Client::new(oauth_config)?;
 
     // Get authorization URL
-    let (auth_url, csrf_token) = oauth_client.get_authorization_url();
+    let (auth_url, _csrf_token) = oauth_client.get_authorization_url();
 
     info!("Opening browser for authorization...");
     info!("If the browser doesn't open, visit: {}", auth_url);
@@ -95,11 +95,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Waiting for OAuth callback on port {}...", args.port);
 
     let (code, state) = callback_server.wait_for_callback().await?;
-
-    // Verify CSRF token
-    if state != *csrf_token.secret() {
-        return Err("CSRF token mismatch".into());
-    }
 
     info!("Received authorization code, exchanging for token...");
 


### PR DESCRIPTION
## Summary
- persist CSRF token generated by `get_authorization_url`
- validate provided state against stored token in `exchange_code`
- remove manual state checking from OAuth examples

## Testing
- `cargo test --workspace --no-run`
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo clippy --tests --examples` *(fails: clippy not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f4c471bb083339de3e7af52f865fe