### PR TITLE
Update OAuth registration endpoint discovery error handling

### DIFF
--- a/crates/tenx-mcp/src/auth/dynamic_registration.rs
+++ b/crates/tenx-mcp/src/auth/dynamic_registration.rs
@@ -253,8 +253,11 @@ impl DynamicRegistrationClient {
             .await
             .map_err(|e| Error::TransportError(format!("Failed to fetch OAuth metadata: {e}")))?;
 
-        if !response.status().is_success() {
-            return Ok(None);
+        let status = response.status();
+        if !status.is_success() {
+            return Err(Error::AuthorizationFailed(format!(
+                "Metadata request failed with status: {status}"
+            )));
         }
 
         let metadata: serde_json::Value = response.json().await.map_err(|e| {

--- a/crates/tenx-mcp/src/auth/oauth_client.rs
+++ b/crates/tenx-mcp/src/auth/oauth_client.rs
@@ -83,15 +83,14 @@ impl OAuth2Client {
             // Try to discover registration endpoint
             match registration_client
                 .discover_registration_endpoint(&issuer)
-                .await
+                .await?
             {
-                Ok(Some(endpoint)) => endpoint,
-                Ok(None) => {
+                Some(endpoint) => endpoint,
+                None => {
                     return Err(Error::InvalidConfiguration(
                         "No registration endpoint found in OAuth metadata".to_string(),
                     ));
                 }
-                Err(e) => return Err(e),
             }
         };
 


### PR DESCRIPTION
## Summary
- return `AuthorizationFailed` when OAuth metadata discovery returns a non-success HTTP status
- propagate this error in `OAuth2Client::register_dynamic`

## Testing
- `cargo fmt` *(fails: `'cargo-fmt' is not installed`)*
- `cargo clippy --tests --examples` *(fails: `'cargo-clippy' is not installed`)*

------
https://chatgpt.com/codex/tasks/task_e_685f5f0561748333b4ba8e1efb0a2967